### PR TITLE
Fixes 'Passing a class...' deprecation warning

### DIFF
--- a/app/models/concerns/spree/vendor_concern.rb
+++ b/app/models/concerns/spree/vendor_concern.rb
@@ -3,7 +3,7 @@ module Spree
     extend ActiveSupport::Concern
 
     included do
-      belongs_to :vendor, class_name: Spree::Vendor
+      belongs_to :vendor, class_name: 'Spree::Vendor'
 
       scope :with_vendor, ->(vendor_id) { where(vendor_id: vendor_id) }
     end

--- a/app/models/spree/user_decorator.rb
+++ b/app/models/spree/user_decorator.rb
@@ -1,4 +1,4 @@
 Spree.user_class.class_eval do
-  has_many :vendor_users, class_name: Spree::VendorUser
-  has_many :vendors, through: :vendor_users, class_name: Spree::Vendor
+  has_many :vendor_users, class_name: 'Spree::VendorUser'
+  has_many :vendors, through: :vendor_users, class_name: 'Spree::Vendor'
 end

--- a/app/models/spree/vendor_user.rb
+++ b/app/models/spree/vendor_user.rb
@@ -1,7 +1,7 @@
 module Spree
   class VendorUser < Spree::Base
-    belongs_to :vendor, class_name: Spree::Vendor
-    belongs_to :user, class_name: Spree.user_class
+    belongs_to :vendor, class_name: 'Spree::Vendor'
+    belongs_to :user, class_name: Spree.user_class.to_s
 
     validates :vendor_id, uniqueness: { scope: :user_id }
   end


### PR DESCRIPTION
Warnings like:
```
DEPRECATION WARNING: Passing a class to the `class_name` is deprecated and will raise an ArgumentError in Rails 5.2. It eagerloads more classes than necessary and potentially creates circular dependencies. Please pass the class name as a string: `belongs_to :vendor, class_name: 'Spree::Vendor'`
```