### PR TITLE
fix: updating vendor without translations attributes cause error

### DIFF
--- a/app/controllers/spree/admin/vendors_controller.rb
+++ b/app/controllers/spree/admin/vendors_controller.rb
@@ -45,6 +45,7 @@ module Spree
       end
 
       def format_translations
+        return if params[:vendor][:translations_attributes].blank?
         params[:vendor][:translations_attributes].each do |_, data|
           translation = @vendor.translations.find_or_create_by(locale: data[:locale])
           translation.name = data[:name]


### PR DESCRIPTION
https://github.com/spree-contrib/spree_multi_vendor/issues/104#issuecomment-628171400 related
Using Globalize, when updating a vendor it always expects to have translations params, causing an error.

