### PR TITLE
[SDP-260] Adds permission for admin action to vendor

### DIFF
--- a/app/models/spree/vendor_ability.rb
+++ b/app/models/spree/vendor_ability.rb
@@ -79,7 +79,7 @@ class Spree::VendorAbility
   end
 
   def apply_prototypes_permissions
-    can :read, Spree::Prototype
+    can [:read, :admin], Spree::Prototype
   end
 
   def apply_shipment_permissions


### PR DESCRIPTION
It seems that we need permission for a vendor to use the `admin` action if we want a vendor to be able to create new products using prototypes. Related to this issue: https://spark-solutions.atlassian.net/browse/SDP-260
<img width="1384" alt="Screenshot 2020-07-09 12 48 18" src="https://user-images.githubusercontent.com/5177038/87034215-c54d3900-c1e7-11ea-8f40-7ac25261b761.png">
