### PR TITLE
Fix Spree::Stock::PackageDecorator;  Don't assign boolean value to `vendor`

### DIFF
--- a/app/models/spree/stock/package_decorator.rb
+++ b/app/models/spree/stock/package_decorator.rb
@@ -1,6 +1,6 @@
 module Spree::Stock::PackageDecorator
   def shipping_methods
-    if (vendor = stock_location.vendor && Spree::ShippingMethod.method_defined?(:vendor))
+    if ((vendor = stock_location.vendor) && Spree::ShippingMethod.method_defined?(:vendor))
       vendor.shipping_methods.to_a
     else
       shipping_categories.map(&:shipping_methods).reduce(:&).to_a


### PR DESCRIPTION
Hi there,

Today, when I reflected the #130  change in our code (`Spree::Stock::PackageDecorator`),  it didn't work.

```
NoMethodError
undefined method `shipping_methods' for true:TrueClass
```

On [this line](https://github.com/spree-contrib/spree_multi_vendor/blob/80ca1c73e86fdc052ead4503ff6a61933d4e52b9/app/models/spree/stock/package_decorator.rb#L4).

It's probably unintended behavior to assign boolean to `vendor`.

--------

This is the patch. https://github.com/spree-contrib/spree_multi_vendor/commit/05428ae180bd14c453b6c3750adc53fe08addf24

I would be happy if you could see it.

Thank you!