### PR TITLE
Fix Order#vendor_ids not to include nil

### DIFF
--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -86,7 +86,7 @@ module Spree::OrderDecorator
   # we're leaving this on purpose so it can be easily modified to fit desired scenario
   # eg. scenario A - vendorized products, scenario B - vendorized variants of the same product
   def vendor_ids
-    line_items.map { |line_item| line_item.product.vendor_id }.uniq
+    line_items.map { |line_item| line_item.product.vendor_id }.uniq.compact
   end
 
   def vendor_totals

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -164,7 +164,7 @@ describe Spree::Order do
       it { expect(order.vendor_ids).to match_array([vendor.id, vendor_2.id]) }
 
       context 'when a line item does not belong to any vendor' do
-        before { order.vendor_line_items(vendor_2).update_all(vendor_id: nil) }
+        before { order.vendor_line_items(vendor_2).each { |li| li.product.update_columns(vendor_id: nil) } }
         it { expect(order.vendor_ids).to match_array([vendor.id]) }
       end
     end

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -162,6 +162,11 @@ describe Spree::Order do
 
     describe '#vendor_ids' do
       it { expect(order.vendor_ids).to match_array([vendor.id, vendor_2.id]) }
+
+      context 'when a line item does not belong to any vendor' do
+        before { order.vendor_line_items(vendor_2).update_all(vendor_id: nil) }
+        it { expect(order.vendor_ids).to match_array([vendor.id]) }
+      end
     end
 
     describe '#vendor_totals' do


### PR DESCRIPTION
It seems that the array returned by `Order#vendor_ids` should not contain `nil`.

In case it does, it causes `ActiveRecord::RecordNotFound`, in this line:

https://github.com/spree-contrib/spree_multi_vendor/blame/2e8db210e3eea656c642b108f1d8ea748c8acd55/app/mailers/spree/vendor_mailer.rb#L4

This pull request solves it.