### PR TITLE
load vendors when update product

### DIFF
--- a/app/controllers/spree_multi_vendor/spree/admin/products_controller_decorator.rb
+++ b/app/controllers/spree_multi_vendor/spree/admin/products_controller_decorator.rb
@@ -1,7 +1,7 @@
 module SpreeMultiVendor::Spree::Admin::ProductsControllerDecorator
   def self.prepended(base)
     base.before_action :set_vendor_id, only: [:create, :update]
-    base.before_action :load_vendors, only: [:new, :edit]
+    base.before_action :load_vendors, only: [:new, :edit, :update]
   end
 
   def stock


### PR DESCRIPTION
When saving product and product's shipping category is empty, instead of showing "Shipping Category can't be blank", the page shows error: "NoMethodError in Spree::Admin::Products#update", undefined method `map' for nil:NilClass, source from <%= f.collection_select(:vendor_id, @vendors, :id, :name, { include_blank: Spree.t('match_choices.none') }, { class: 'select2' }) %>