### PR TITLE
Fix: product image cancan rule, to avoid CanCan::Error

### DIFF
--- a/app/models/spree/vendor_ability.rb
+++ b/app/models/spree/vendor_ability.rb
@@ -42,8 +42,9 @@ class Spree::VendorAbility
   def apply_image_permissions
     can :create, Spree::Image
 
-    can [:manage, :modify], Spree::Image do |image|
-      image.viewable_type == 'Spree::Variant' && @vendor_ids.include?(image.viewable.vendor_id)
+    can [:manage, :modify], Spree::Image, ['viewable_type = ?', 'Spree::Variant'] do |image|
+      vendor_id = image.viewable.try(:vendor_id)
+      vendor_id.present? && @vendor_ids.include?(vendor_id)
     end
   end
 


### PR DESCRIPTION
## Description

The cancan rule for image_permissions for vendors was changed and defined according the following documentation:

- https://github.com/ryanb/cancan/wiki/Defining-Abilities-with-Blocks#fetching-records

## Related Issue

close #163 

# Motivation and Context

When we try to access to the product images endpoint in APIv1, using the token of the vendor associated to the product. We got a `CanCan::Error`.

- The vendor must be *active*
- More info in the issue #163 