### PR TITLE
Fix a flaky test

### DIFF
--- a/spec/requests/spree/api/v2/storefront/products_spec.rb
+++ b/spec/requests/spree/api/v2/storefront/products_spec.rb
@@ -26,6 +26,8 @@ describe 'API V2 Storefront Products Spec', type: :request do
     end
 
     context 'with specified vendor ids' do
+      before { vendor.products << create(:product) }
+      before { vendor_2.products << create(:product) }
       before { get "/api/v2/storefront/products?filter[vendor_ids]=#{vendor.id}&include=vendor" }
 
       it_behaves_like 'returns 200 HTTP status'


### PR DESCRIPTION
So far, `json_response['included'].first` can be nil because of randomness.

failed build example: https://travis-ci.com/github/spree-contrib/spree_multi_vendor/builds/217630846