### PR TITLE
Fix #144 : Don't re-assign value to METHOD_NAMES if it is already defined

### DIFF
--- a/app/models/spree_multi_vendor/spree/order_decorator.rb
+++ b/app/models/spree_multi_vendor/spree/order_decorator.rb
@@ -66,7 +66,7 @@ module SpreeMultiVendor::Spree::OrderDecorator
   end
 
   # money methods
-  METHOD_NAMES = %w[
+  METHOD_NAMES ||= %w[
     total ship_total subtotal included_tax_total additional_tax_total promo_total
     pre_tax_item_amount pre_tax_ship_amount pre_tax_total commission
   ].freeze


### PR DESCRIPTION
Fix #144 

Same approach as https://github.com/spree/spree/pull/10498 .


## before

<img width="563" alt="スクリーンショット 2021-03-07 23 41 06" src="https://user-images.githubusercontent.com/1394049/110243647-a4b7c780-7f9e-11eb-9174-54c2e4835c8e.png">



## after




<img width="561" alt="スクリーンショット 2021-03-07 23 40 31" src="https://user-images.githubusercontent.com/1394049/110243648-a5505e00-7f9e-11eb-838a-baedae8bbf02.png">
