### PR TITLE
Fix main menu deface when current_user doesn't exists

### DIFF
--- a/app/overrides/spree/admin/shared/_main_menu.rb
+++ b/app/overrides/spree/admin/shared/_main_menu.rb
@@ -2,7 +2,7 @@ Deface::Override.new(
   virtual_path: 'spree/admin/shared/_main_menu',
   name: 'Display configuration tab for vendors',
   replace: 'erb[silent]:contains("current_store")',
-  text: '<% if can?(:admin, current_store) || current_spree_user.vendors.any? %>'
+  text: '<% if can?(:admin, current_store) || current_spree_user&.vendors&.any? %>'
 )
 Deface::Override.new(
   virtual_path:  'spree/admin/shared/_main_menu',


### PR DESCRIPTION
Context:

When user visit /admin/password/recover the app throws this error

`ActionView::Template::Error (undefined method `vendors' for nil:NilClass)`