### PR TITLE
fix `VariantDecorator`'s reference to `product` when there is no `product`

### DIFF
--- a/app/models/spree_multi_vendor/spree/variant_decorator.rb
+++ b/app/models/spree_multi_vendor/spree/variant_decorator.rb
@@ -7,7 +7,6 @@ module SpreeMultiVendor::Spree::VariantDecorator
 
   def vendor
     @vendor ||= if self.class.reflect_on_association(:vendor) && self[:vendor_id].present?
-                  product.vendor
                   ::Spree::Vendor.unscoped.find(self[:vendor_id])
                 elsif Spree::Product.reflect_on_association(:vendor) && product.vendor_id.present?
                   product.vendor


### PR DESCRIPTION
This PR resolves #196, which flagged a bug that prevents vendors from signing up. 

In `variant_decorator#vendor`, when a vendor is assigned to a variant, it tries to use either `variant.vendor` or `product.vendor`; but after the check, `product.vendor` is used anyway. This causes issues during signup when there is no associated product yet. 

