### PR TITLE
Fix irreversible type change migrations

### DIFF
--- a/db/migrate/20210728120910_change_vendor_id_and_user_id_type_for_spree_vendor_users.rb
+++ b/db/migrate/20210728120910_change_vendor_id_and_user_id_type_for_spree_vendor_users.rb
@@ -1,8 +1,14 @@
 class ChangeVendorIdAndUserIdTypeForSpreeVendorUsers < ActiveRecord::Migration[4.2]
-  def change
+  def up
     change_table(:spree_vendor_users) do |t|
       t.change :vendor_id, :bigint
       t.change :user_id, :bigint
+    end
+  end
+  def down
+    change_table(:spree_vendor_users) do |t|
+      t.change :vendor_id, :integer
+      t.change :user_id, :integer
     end
   end
 end

--- a/db/migrate/20210728121024_change_vendor_id_and_order_id_type_for_spree_order_commissions.rb
+++ b/db/migrate/20210728121024_change_vendor_id_and_order_id_type_for_spree_order_commissions.rb
@@ -1,8 +1,14 @@
 class ChangeVendorIdAndOrderIdTypeForSpreeOrderCommissions < ActiveRecord::Migration[4.2]
-  def change
+  def up
     change_table(:spree_order_commissions) do |t|
       t.change :vendor_id, :bigint
       t.change :order_id, :bigint
+    end
+  end
+  def down
+    change_table(:spree_order_commissions) do |t|
+      t.change :vendor_id, :integer
+      t.change :order_id, :integer
     end
   end
 end


### PR DESCRIPTION
This fixes issue #203, where the migrations that changes the type of `vendor_id`, `order_id` and `user_id` from integer to bigint were irreversible.