### PR TITLE
Fix NameError (uninitialized constant Spree::BaseMailer) which occurs when referencing Spree::VendorMailer

### DIFF
--- a/lib/spree_multi_vendor.rb
+++ b/lib/spree_multi_vendor.rb
@@ -1,5 +1,6 @@
 require 'spree_core'
 require 'spree_backend'
+require 'spree_emails'
 require 'spree_multi_vendor/engine'
 require 'spree_multi_vendor/version'
 require 'spree_extension'


### PR DESCRIPTION

fix https://github.com/spree-contrib/spree_multi_vendor/issues/208