### PR TITLE
Fix: remove redundant `Spree.t`

### DIFF
--- a/app/overrides/spree/admin/users/_form.rb
+++ b/app/overrides/spree/admin/users/_form.rb
@@ -5,7 +5,7 @@ Deface::Override.new(
   text: <<-HTML
           <% if current_spree_user.respond_to?(:has_spree_role?) && current_spree_user.has_spree_role?(:admin) %>
             <%= f.field_container :vendor_ids, class: ['form-group'] do %>
-              <%= f.label :vendor_ids, Spree.t(plural_resource_name(Spree::Vendor)) %>
+              <%= f.label :vendor_ids, plural_resource_name(Spree::Vendor) %>
               <%= f.collection_select(:vendor_ids, Spree::Vendor.all, :id, :name, { }, { class: 'select2', multiple: true }) %>
             <% end %>
           <% end %>

--- a/app/views/spree/admin/vendors/index.html.erb
+++ b/app/views/spree/admin/vendors/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= Spree.t(plural_resource_name(Spree::Vendor)) %>
+  <%= plural_resource_name(Spree::Vendor) %>
 <% end %>
 
 <% content_for :page_actions do %>


### PR DESCRIPTION
fix https://github.com/spree-contrib/spree_multi_vendor/issues/210

`#plural_resource_name` returns translated string.

Therefore, `Spree.t` is not needed for these lines.

This change avoids `I18n.MissingTranslationData` exception.