### PR TITLE
Use the default stores default_country

### DIFF
--- a/app/models/spree/vendor.rb
+++ b/app/models/spree/vendor.rb
@@ -61,7 +61,7 @@ module Spree
     private
 
     def create_stock_location
-      stock_locations.where(name: name, country: Spree::Country.default).first_or_create!
+      stock_locations.where(name: name, country: Spree::Store.default.default_country).first_or_create!
     end
 
     def should_generate_new_friendly_id?


### PR DESCRIPTION
Country.default is deprecated. Use the `Spree::Store.default.default_country` instead.