### PR TITLE
fix: Update namespace of api v1 legacy

### DIFF
--- a/app/controllers/spree/api/v1/vendors_controller.rb
+++ b/app/controllers/spree/api/v1/vendors_controller.rb
@@ -1,7 +1,7 @@
 module Spree
   module Api
     module V1
-      class VendorsController < Spree::Api::BaseController
+      class VendorsController < Spree::Api::V1::BaseController
         def index
           @vendors = if params[:ids].present?
                        scope.where(id: params[:ids].split(','))

--- a/app/controllers/spree_multi_vendor/spree/api/base_controller_decorator.rb
+++ b/app/controllers/spree_multi_vendor/spree/api/base_controller_decorator.rb
@@ -1,5 +1,5 @@
 module SpreeMultiVendor::Spree::Api::BaseControllerDecorator
-  Spree::Api::BaseController.include(Spree::Api::VendorHelper)
+  Spree::Api::V1::BaseController.include(Spree::Api::VendorHelper) if SpreeMultiVendor::Engine.api_v1_available?
 
   def self.prepended(base)
     base.helper_method :current_spree_vendor
@@ -14,4 +14,4 @@ module SpreeMultiVendor::Spree::Api::BaseControllerDecorator
   end
 end
 
-::Spree::Api::BaseController.prepend SpreeMultiVendor::Spree::Api::BaseControllerDecorator
+::Spree::Api::V1::BaseController.prepend SpreeMultiVendor::Spree::Api::BaseControllerDecorator if SpreeMultiVendor::Engine.api_v1_available?

--- a/app/controllers/spree_multi_vendor/spree/api/v1/products_controller_decorator.rb
+++ b/app/controllers/spree_multi_vendor/spree/api/v1/products_controller_decorator.rb
@@ -6,4 +6,4 @@ module SpreeMultiVendor::Spree::Api::V1::ProductsControllerDecorator
   end
 end
 
-Spree::Api::V1::ProductsController.prepend SpreeMultiVendor::Spree::Api::V1::ProductsControllerDecorator
+Spree::Api::V1::ProductsController.prepend SpreeMultiVendor::Spree::Api::V1::ProductsControllerDecorator if SpreeMultiVendor::Engine.api_v1_available?

--- a/app/controllers/spree_multi_vendor/spree/api/v1/users_controller_decorator.rb
+++ b/app/controllers/spree_multi_vendor/spree/api/v1/users_controller_decorator.rb
@@ -10,4 +10,4 @@ module SpreeMultiVendor::Spree::Api::V1::UsersControllerDecorator
   end
 end
 
-Spree::Api::V1::UsersController.prepend SpreeMultiVendor::Spree::Api::V1::UsersControllerDecorator
+Spree::Api::V1::UsersController.prepend SpreeMultiVendor::Spree::Api::V1::UsersControllerDecorator if SpreeMultiVendor::Engine.api_v1_available?

--- a/app/helpers/spree_multi_vendor/spree/api/api_helpers_decorator.rb
+++ b/app/helpers/spree_multi_vendor/spree/api/api_helpers_decorator.rb
@@ -16,4 +16,4 @@ module SpreeMultiVendor
   end
 end
 
-::Spree::Api::ApiHelpers.prepend(SpreeMultiVendor::Spree::Api::ApiHelpersDecorator)
+::Spree::Api::ApiHelpers.prepend(SpreeMultiVendor::Spree::Api::ApiHelpersDecorator) if SpreeMultiVendor::Engine.api_v1_available?

--- a/lib/spree_multi_vendor/engine.rb
+++ b/lib/spree_multi_vendor/engine.rb
@@ -19,6 +19,10 @@ module SpreeMultiVendor
       end
     end
 
+    def self.api_v1_available?
+      @@api_v1_available ||= Gem::Specification.find_all_by_name('spree_api_v1').any?
+    end
+
     config.to_prepare &method(:activate).to_proc
   end
 end


### PR DESCRIPTION
# WHEN
  When use spree_multi_vendor with spree_api_v1 base_controller namspace is broken, and load unnecessary files and broken when do not use spree_api_v1

# CHANGES  
  - add api_v1_available? method to engine
  - change namespace on base_controller_decorator.rb
  - change namespace on products_controller_decorator.rb
  - change namespace on users_controller_decorator.rb
  - change namespace base on vendors_controller.rb
  - add conditional to load api_helpers_decorator.rb