### PR TITLE
Fix:  Translation missing: En.Spree.Vendors

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -25,6 +25,7 @@ en:
         subject: Vendor notification
         thanks: Thanks
     vendor: Vendor
+    vendors: Vendors
     vendor_name: Vendor Name
     vendor_states:
       active: Active

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -27,6 +27,7 @@ es:
         subject: Notificación de vendedor
         thanks: Gracias
     vendor: Vendedor
+    vendors: Vendedores
     vendor_name: Nombre del vendedor
     vendor_states:
       active: Activo

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -24,6 +24,7 @@ fr:
         subject: Notification vendeur
         thanks: Merci
     vendor: Vendeur
+    vendor: Vendeurs
     vendor_name: Nom du vendeur
     vendor_states:
       active: Actif


### PR DESCRIPTION
A translation key is missing at least on spree 4.5.0 with spree_multi_vendor 2.4.0:

![translation missing](https://user-images.githubusercontent.com/19952317/209446061-149e7fad-9361-4a21-9c5f-62a1b0742b95.png)

This PR adds the missing key for all locales. Please let me known if changes are required.
Thanks