### PR TITLE
feat: changes related to spree 4.5.0

### DIFF
--- a/app/overrides/spree/admin/shared/_main_menu.rb
+++ b/app/overrides/spree/admin/shared/_main_menu.rb
@@ -4,20 +4,3 @@ Deface::Override.new(
   replace: 'erb[silent]:contains("current_store")',
   text: '<% if can?(:admin, current_store) || current_spree_user&.vendors&.any? %>'
 )
-Deface::Override.new(
-  virtual_path:  'spree/admin/shared/_main_menu',
-  name:          'vendors_main_menu_tabs',
-  insert_bottom: 'nav',
-  text:       <<-HTML
-                <% if current_spree_user.respond_to?(:has_spree_role?) && current_spree_user.has_spree_role?(:admin) %>
-                  <ul class="nav nav-sidebar border-bottom">
-                    <%= tab plural_resource_name(Spree::Vendor), url: admin_vendors_path, icon: 'money' %>
-                  </ul>
-                <% end %>
-                <% if defined?(current_spree_vendor) && current_spree_vendor %>
-                  <ul class="nav nav-sidebar border-bottom">
-                    <%= tab Spree::Vendor.model_name.human, url: admin_vendor_settings_path, icon: 'money' %>
-                  </ul>
-                <% end %>
-HTML
-)

--- a/app/views/spree/admin/vendors/index.html.erb
+++ b/app/views/spree/admin/vendors/index.html.erb
@@ -33,7 +33,7 @@
 <%= render partial: 'spree/admin/shared/index_table_options', locals: { collection: @collection } %>
 
 <% if @vendors.any? %>
-  <table class="table sortable" data-hook="vendors_table" data-sortable-link="<%= update_positions_admin_vendors_url %>">
+  <table class="table border rounded sortable" data-hook="vendors_table" data-sortable-link="<%= update_positions_admin_vendors_url %>">
     <thead>
       <tr data-hook="vendors_header">
         <th>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,3 +32,4 @@ en:
       pending: Pending
     admin:
       commission: Commission
+    vendors: Vendors

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -34,3 +34,4 @@ es:
       pending: Pendiente
     admin:
       commission: Comisión
+    vendors: Vendedores

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -31,3 +31,4 @@ fr:
       pending: En attente
     admin:
       commission: Commission
+    vendors: Vendeurs


### PR DESCRIPTION
  - add new style related to spree 4.5.0 on table(index page)
  - add missing translations(es, en and fr) -> this new field to translate it was added to spree_backend, maybe should be added on spree_backend and not here
  - remove duplicated item on sidebar



