### PR TITLE
Fix engine configuration

### DIFF
--- a/lib/spree_multi_vendor/configuration.rb
+++ b/lib/spree_multi_vendor/configuration.rb
@@ -1,10 +1,27 @@
 module SpreeMultiVendor
-  class Configuration < ::Spree::Preferences::Configuration
+  class Configuration
     DEFAULT_VENDORIZED_MODELS ||= %w[product variant stock_location shipping_method].freeze
 
-   # Some example preferences are shown below, for more information visit:
-   # https://guides.spreecommerce.org/developer/core/preferences.html
+    attr_accessor :vendorized_models
 
-   preference :vendorized_models, :array, default: DEFAULT_VENDORIZED_MODELS
+    def initialize
+      self.vendorized_models = DEFAULT_VENDORIZED_MODELS
+    end
+
+    def configure
+      yield(self) if block_given?
+    end
+
+    def get(preference)
+      send(preference)
+    end
+
+    alias [] get
+
+    def set(preference, value)
+      send("#{preference}=", value)
+    end
+
+    alias []= set
   end
 end


### PR DESCRIPTION
The previous solution persisted vendorized models in the database. This causes problems with Rails 7 autoloader. It also doesn't make much sense, since this is not something that can be configured via the admin panel.

I've extracted it to a simple object that conforms to the old interface, but doesn't rely on the database.