### PR TITLE
Improve mobility support

### DIFF
--- a/app/controllers/spree/admin/vendors_controller.rb
+++ b/app/controllers/spree/admin/vendors_controller.rb
@@ -1,6 +1,7 @@
 module Spree
   module Admin
     class VendorsController < ResourceController
+      include Translatable
 
       def create
         if permitted_resource_params[:image]
@@ -13,7 +14,6 @@ module Spree
         if permitted_resource_params[:image]
           @vendor.create_image(attachment: permitted_resource_params.delete(:image))
         end
-        format_translations if defined? SpreeGlobalize
         super
       end
 
@@ -50,18 +50,6 @@ module Spree
           image: [],
           products: []
         }
-      end
-
-      def format_translations
-        return if params[:vendor][:translations_attributes].blank?
-        params[:vendor][:translations_attributes].each do |_, data|
-          translation = @vendor.translations.find_or_create_by(locale: data[:locale])
-          translation.name = data[:name]
-          translation.about_us = data[:about_us]
-          translation.contact_us = data[:contact_us]
-          translation.slug = data[:slug]
-          translation.save!
-        end
       end
     end
   end

--- a/app/models/spree/vendor.rb
+++ b/app/models/spree/vendor.rb
@@ -1,6 +1,11 @@
 module Spree
   class Vendor < Spree::Base
     extend FriendlyId
+    include TranslatableResource
+    include TranslatableResourceSlug
+
+    TRANSLATABLE_FIELDS = %i[name about_us contact_us slug].freeze
+    translates(*TRANSLATABLE_FIELDS)
 
     acts_as_paranoid
     acts_as_list column: :priority
@@ -46,16 +51,6 @@ module Spree
 
     def update_notification_email(email)
       update(notification_email: email)
-    end
-
-    # Spree Globalize support
-    # https://github.com/spree-contrib/spree_multi_vendor/issues/104
-    if defined?(SpreeGlobalize)
-      attr_accessor :translations_attributes
-      translates :name,
-                 :about_us,
-                 :contact_us,
-                 :slug, fallbacks_for_empty_translations: true
     end
 
     private

--- a/app/overrides/spree/admin/shared/_main_menu.rb
+++ b/app/overrides/spree/admin/shared/_main_menu.rb
@@ -1,6 +1,0 @@
-Deface::Override.new(
-  virtual_path: 'spree/admin/shared/_main_menu',
-  name: 'Display configuration tab for vendors',
-  replace: 'erb[silent]:contains("current_store")',
-  text: '<% if can?(:admin, current_store) || current_spree_user&.vendors&.any? %>'
-)

--- a/app/views/spree/admin/vendors/index.html.erb
+++ b/app/views/spree/admin/vendors/index.html.erb
@@ -66,9 +66,9 @@
             <!-- Add translation icon support -->
             <%= link_to_with_icon 'translate',
                                   nil,
-                                  spree.admin_translations_path('vendor', vendor.id),
+                                  spree.translations_admin_vendor_path(vendor.id),
                                   title: Spree.t(:'i18n.translations'),
-                                  class: 'btn btn-sm btn-primary' if defined? (SpreeGlobalize)%>
+                                  class: 'btn btn-sm btn-primary' %>
           </td>
         </tr>
       <% end %>

--- a/app/views/spree/admin/vendors/translations.html.erb
+++ b/app/views/spree/admin/vendors/translations.html.erb
@@ -1,0 +1,3 @@
+<div class="row" style="display: block">
+  <%= render 'spree/admin/translations/form', resource: @object %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,11 @@
 Spree::Core::Engine.routes.draw do
   namespace :admin do
     resources :vendors do
+      member do
+        get :translations
+        post :translations, to: 'vendors#edit_translations'
+      end
+
       collection do
         post :update_positions
       end

--- a/db/migrate/20231114090744_add_mobility_translations_to_vendor.rb
+++ b/db/migrate/20231114090744_add_mobility_translations_to_vendor.rb
@@ -1,0 +1,25 @@
+class AddMobilityTranslationsToVendor < ActiveRecord::Migration[6.1]
+  def change
+    if ActiveRecord::Base.connection.table_exists?('spree_vendor_translations')
+      if ActiveRecord::Migration.connection.index_exists?(:spree_vendors_translations, :spree_vendor_id)
+        remove_index :spree_vendor_translations, column: :spree_vendor_id, if_exists: true
+      end
+    else
+      create_table :spree_vendor_translations do |t|
+        # Translated attribute(s)
+        t.string :name
+        t.text :about_us
+        t.text :contact_us
+        t.string :slug
+
+        t.string  :locale, null: false
+        t.references :spree_vendor, null: false, foreign_key: true, index: false
+
+        t.timestamps null: false
+      end
+
+      add_index :spree_vendor_translations, :locale, name: :index_spree_vendor_translations_on_locale
+      add_index :spree_vendor_translations, [:locale, :slug], unique: true, name: 'vendor_unique_slug_per_locale'
+    end
+  end
+end

--- a/db/migrate/20231114093444_transfer_vendor_data_to_translatable_tables.rb
+++ b/db/migrate/20231114093444_transfer_vendor_data_to_translatable_tables.rb
@@ -1,0 +1,11 @@
+class TransferVendorDataToTranslatableTables < ActiveRecord::Migration[6.1]
+  TRANSLATION_MIGRATION = Spree::TranslationMigrations.new(Spree::Vendor, 'en')
+
+  def up
+    TRANSLATION_MIGRATION.transfer_translation_data
+  end
+
+  def down
+    TRANSLATION_MIGRATION.revert_translation_data_transfer
+  end
+end

--- a/spree_multi_vendor.gemspec
+++ b/spree_multi_vendor.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  spree_version = '>= 4.3.0.rc1'
+  spree_version = '>= 4.6.0'
   s.add_dependency 'spree', spree_version
   s.add_dependency 'spree_backend', spree_version
   s.add_dependency 'spree_emails', spree_version


### PR DESCRIPTION
This PR uses modules available in Spree 4.6+ for handling translations on the Vendor entity