### PR TITLE
fix: Add a `vendor_id` column to the `spree_orders` table

### DIFF
--- a/db/migrate/20231214071613_add_vendor_id_to_spree_orders.rb
+++ b/db/migrate/20231214071613_add_vendor_id_to_spree_orders.rb
@@ -1,0 +1,5 @@
+class AddVendorIdToSpreeOrders < ActiveRecord::Migration[7.0]
+  def change
+    add_column :spree_orders, :vendor_id, :bigint
+  end
+end


### PR DESCRIPTION
PG::UndefinedColumn: ERROR:  column spree_orders.vendor_id does not exist
LINE 1: ..._orders" WHERE "spree_orders"."store_id" = $1 AND "spree_ord...