### PR TITLE
[SP-120] Infer default country from Store

### DIFF
--- a/spec/models/spree/vendor_spec.rb
+++ b/spec/models/spree/vendor_spec.rb
@@ -36,7 +36,7 @@ describe Spree::Vendor do
       expect { vendor.save! }.to change(Spree::StockLocation, :count).by(1)
       stock_location = Spree::StockLocation.last
       expect(vendor.stock_locations.first).to eq stock_location
-      expect(stock_location.country).to eq Spree::Country.default
+      expect(stock_location.country).to eq Spree::Store.default.default_country
     end
 
     it 'should act as list' do


### PR DESCRIPTION
### **What?**
[SP-120](https://upsidelab.atlassian.net/browse/SP-120)
Infer default country from Store instead of config.


### **Why?**
Spree no longer uses Spree::Config[:default_country_id] - it's now managed at per-store level.