### PR TITLE
Fix NoMethodError on nil.distinct in ProductsFinderDecorator

### DIFF
--- a/app/finders/spree_multi_vendor/products_finder_decorator.rb
+++ b/app/finders/spree_multi_vendor/products_finder_decorator.rb
@@ -9,7 +9,7 @@ module SpreeMultiVendor
     def execute
       products = by_vendors(super)
 
-      products.distinct
+      products.try(:distinct)
     end
 
     private


### PR DESCRIPTION
- Added a safeguard in the `execute` method of ProductsFinderDecorator to handle cases where no products are found.
- Ensures `distinct` is only called on a non-nil object.